### PR TITLE
Add ports to NetworkMapping for Kubernetes

### DIFF
--- a/engine/docker/convert.go
+++ b/engine/docker/convert.go
@@ -3,11 +3,9 @@ package docker
 import (
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/go-connections/nat"
 	"github.com/drone/drone-runtime/engine"
 )
 
@@ -21,26 +19,11 @@ func toConfig(proc *engine.Step) *container.Config {
 		AttachStderr: true,
 	}
 
-	if len(proc.Networks) != 0 {
-		ports := make(nat.PortSet)
-		for _, network := range proc.Networks {
-			for _, port := range network.Ports {
-				natPort, err := nat.NewPort("TCP", fmt.Sprintf("%d", port))
-				if err != nil {
-					panic(err)
-				}
-				ports[natPort] = struct{}{}
-			}
-		}
-		config.ExposedPorts = ports
-	}
-
-	for _, secret := range proc.Secrets {
-		config.Env = append(config.Env, secret.Name+"="+secret.Value)
-	}
-
 	if len(proc.Environment) != 0 {
 		config.Env = toEnv(proc.Environment)
+	}
+	for _, secret := range proc.Secrets {
+		config.Env = append(config.Env, secret.Name+"="+secret.Value)
 	}
 	if len(proc.Command) != 0 {
 		config.Cmd = proc.Command

--- a/engine/docker/convert.go
+++ b/engine/docker/convert.go
@@ -3,9 +3,8 @@ package docker
 import (
 	"encoding/base64"
 	"encoding/json"
-	"strings"
-
 	"fmt"
+	"strings"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"

--- a/engine/docker/convert_test.go
+++ b/engine/docker/convert_test.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/go-connections/nat"
 	"github.com/drone/drone-runtime/engine"
 )
 
@@ -17,20 +16,7 @@ func TestDockerConvertHostConfig(t *testing.T) {
 }
 
 func TestDockerConvertNetwork(t *testing.T) {
-	from := &engine.Step{
-		Networks: []*engine.NetworkMapping{{
-			Name:    "test",
-			Aliases: []string{"foo", "bar"},
-			Ports:   []int{80, 443},
-		}},
-	}
-
-	want := nat.PortSet{"80/TCP": {}, "443/TCP": {}}
-	got := toConfig(from)
-
-	if !reflect.DeepEqual(got.ExposedPorts, want) {
-		t.Errorf("Want network %+v, got %+v", want, got.ExposedPorts)
-	}
+	t.SkipNow()
 }
 
 func TestDockerConvertVolume(t *testing.T) {

--- a/engine/docker/convert_test.go
+++ b/engine/docker/convert_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/drone/drone-runtime/engine"
 )
 
@@ -16,7 +17,19 @@ func TestDockerConvertHostConfig(t *testing.T) {
 }
 
 func TestDockerConvertNetwork(t *testing.T) {
-	t.SkipNow()
+	from := &engine.Step{
+		Networks: []*engine.NetworkMapping{{
+			Name:    "test",
+			Aliases: []string{"foo", "bar"},
+			Ports:   []int{80, 443},
+		}},
+	}
+
+	want := nat.PortSet{}
+	got := toConfig(from)
+	if !reflect.DeepEqual(got.ExposedPorts, want) {
+		t.Errorf("Want network %+v, got %+v", want, got.ExposedPorts)
+	}
 }
 
 func TestDockerConvertVolume(t *testing.T) {
@@ -25,7 +38,7 @@ func TestDockerConvertVolume(t *testing.T) {
 	}
 
 	want := map[string]struct{}{
-		"/root": struct{}{},
+		"/root": {},
 	}
 	got := toVolumeSet(from)
 	if !reflect.DeepEqual(got, want) {

--- a/engine/docker/convert_test.go
+++ b/engine/docker/convert_test.go
@@ -25,8 +25,9 @@ func TestDockerConvertNetwork(t *testing.T) {
 		}},
 	}
 
-	want := nat.PortSet{}
+	want := nat.PortSet{"80/TCP": {}, "443/TCP": {}}
 	got := toConfig(from)
+
 	if !reflect.DeepEqual(got.ExposedPorts, want) {
 		t.Errorf("Want network %+v, got %+v", want, got.ExposedPorts)
 	}

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -66,6 +66,7 @@ type (
 	NetworkMapping struct {
 		Name    string   `json:"name"`
 		Aliases []string `json:"aliases"`
+		Ports   []int    `json:"ports"`
 	}
 
 	// Network defines a container network.


### PR DESCRIPTION
For the drone-kubernetes-runtime we need the ports slice to be passed on to Kubernetes' Services.