### PR TITLE
Split strings with multiple lines

### DIFF
--- a/runtime/line.go
+++ b/runtime/line.go
@@ -37,18 +37,23 @@ func (w *lineWriter) Write(p []byte) (n int, err error) {
 		out = w.rep.Replace(out)
 	}
 
-	line := &Line{
-		Number:    w.num,
-		Message:   out,
-		Timestamp: int64(time.Since(w.now).Seconds()),
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+
+	for _, l := range lines {
+		line := &Line{
+			Number:    w.num,
+			Message:   l + "\n",
+			Timestamp: int64(time.Since(w.now).Seconds()),
+		}
+
+		if w.state.hook.GotLine != nil {
+			w.state.hook.GotLine(w.state, line)
+		}
+		w.num++
+
+		w.lines = append(w.lines, line)
 	}
 
-	if w.state.hook.GotLine != nil {
-		w.state.hook.GotLine(w.state, line)
-	}
-	w.num++
-
-	w.lines = append(w.lines, line)
 	return len(p), nil
 }
 

--- a/runtime/line.go
+++ b/runtime/line.go
@@ -37,12 +37,16 @@ func (w *lineWriter) Write(p []byte) (n int, err error) {
 		out = w.rep.Replace(out)
 	}
 
-	lines := strings.Split(strings.TrimSpace(out), "\n")
+	lines := strings.SplitAfter(out, "\n")
 
 	for _, l := range lines {
+		if l == "" {
+			continue
+		}
+
 		line := &Line{
 			Number:    w.num,
-			Message:   l + "\n",
+			Message:   l,
 			Timestamp: int64(time.Since(w.now).Seconds()),
 		}
 

--- a/runtime/line_test.go
+++ b/runtime/line_test.go
@@ -26,7 +26,7 @@ func TestLineWriter(t *testing.T) {
 	if line == nil {
 		t.Error("Expect LineFunc invoked")
 	}
-	if got, want := line.Message, "foo********\n"; got != want {
+	if got, want := line.Message, "foo********"; got != want {
 		t.Errorf("Got line %q, want %q", got, want)
 	}
 	if got, want := line.Number, 0; got != want {

--- a/runtime/line_test.go
+++ b/runtime/line_test.go
@@ -26,11 +26,47 @@ func TestLineWriter(t *testing.T) {
 	if line == nil {
 		t.Error("Expect LineFunc invoked")
 	}
-	if got, want := line.Message, "foo********"; got != want {
+	if got, want := line.Message, "foo********\n"; got != want {
 		t.Errorf("Got line %q, want %q", got, want)
 	}
 	if got, want := line.Number, 0; got != want {
 		t.Errorf("Got line %d, want %d", got, want)
+	}
+}
+
+func TestMultiLineWriter(t *testing.T) {
+	state := &State{}
+	state.hook = &Hook{}
+	state.Step = &engine.Step{}
+
+	w := newWriter(state)
+
+	written, err := w.Write([]byte("foo\nbar\n"))
+	if err != nil {
+		t.Errorf("Expect no error but got: %v", err)
+	}
+	if written != 8 {
+		t.Errorf("Expect to write 8 chars but written: %d", written)
+	}
+
+	if len(w.lines) != 2 {
+		t.Errorf("Expect 2 lines to be crated, got %d", len(w.lines))
+	}
+
+	expected := []Line{
+		{Number: 0, Message: "foo\n", Timestamp: 0},
+		{Number: 1, Message: "bar\n", Timestamp: 0},
+	}
+	for i, exp := range expected {
+		if w.lines[i].Number != exp.Number {
+			t.Errorf("Got line number %d, want %d", w.lines[i].Number, exp.Number)
+		}
+		if w.lines[i].Message != exp.Message {
+			t.Errorf("Got line %s, want %s", w.lines[i].Message, exp.Message)
+		}
+		if w.lines[i].Timestamp != exp.Timestamp {
+			t.Errorf("Got line timestamp %d, want %d", w.lines[i].Timestamp, exp.Timestamp)
+		}
 	}
 }
 


### PR DESCRIPTION
This will first trim all trailing spaces from the string. Then it splits at all new lines within the string.
Each line then gets added to the slice of lines with a `"\n"` at the end.

Wrote a test and tested it with the Docker and Kubernetes runtimes.

Fixes #11 