### PR TITLE
add limits and requests to kubernetes

### DIFF
--- a/engine/kube/util.go
+++ b/engine/kube/util.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"log"
 	"path"
 	"path/filepath"
 	"strings"
@@ -203,23 +204,37 @@ func toNamespace(spec *engine.Spec) *v1.Namespace {
 
 func toResources(step *engine.Step) v1.ResourceRequirements {
 	var resources v1.ResourceRequirements
-	// TODO (bradrydzewski) createing resource limits is
-	// currently disabled pending a better understanding
-	// of how this works, and the correct format value for
-	// bytes (in memory) as an integer.
-	if true {
-		return resources
-	}
-
 	if step.Resources != nil && step.Resources.Limits != nil {
 		resources.Limits = v1.ResourceList{}
-		resources.Limits[v1.ResourceMemory] = *resource.NewQuantity(
-			step.Resources.Limits.Memory, resource.BinarySI)
+		if step.Resources.Limits.Memory > int64(0) {
+			resources.Limits[v1.ResourceMemory] = *resource.NewQuantity(
+				step.Resources.Limits.Memory, resource.BinarySI)
+		}
+		if step.Resources.Limits.CPU != "" {
+			cpu, err := resource.ParseQuantity(step.Resources.Limits.CPU)
+			if err != nil {
+				// TODO: how we should print this error?
+				log.Println(err)
+			} else {
+				resources.Limits[v1.ResourceCPU] = cpu
+			}
+		}
 	}
 	if step.Resources != nil && step.Resources.Requests != nil {
 		resources.Requests = v1.ResourceList{}
-		resources.Requests[v1.ResourceMemory] = *resource.NewQuantity(
-			step.Resources.Requests.Memory, resource.BinarySI)
+		if step.Resources.Requests.Memory > int64(0) {
+			resources.Requests[v1.ResourceMemory] = *resource.NewQuantity(
+				step.Resources.Requests.Memory, resource.BinarySI)
+		}
+		if step.Resources.Requests.CPU != "" {
+			cpu, err := resource.ParseQuantity(step.Resources.Requests.CPU)
+			if err != nil {
+				// TODO: how we should print this error?
+				log.Println(err)
+			} else {
+				resources.Requests[v1.ResourceCPU] = cpu
+			}
+		}
 	}
 	return resources
 }

--- a/engine/kube/util.go
+++ b/engine/kube/util.go
@@ -1,7 +1,6 @@
 package kube
 
 import (
-	"log"
 	"path"
 	"path/filepath"
 	"strings"
@@ -210,14 +209,9 @@ func toResources(step *engine.Step) v1.ResourceRequirements {
 			resources.Limits[v1.ResourceMemory] = *resource.NewQuantity(
 				step.Resources.Limits.Memory, resource.BinarySI)
 		}
-		if step.Resources.Limits.CPU != "" {
-			cpu, err := resource.ParseQuantity(step.Resources.Limits.CPU)
-			if err != nil {
-				// TODO: how we should print this error?
-				log.Println(err)
-			} else {
-				resources.Limits[v1.ResourceCPU] = cpu
-			}
+		if step.Resources.Limits.CPU > int64(0) {
+			resources.Limits[v1.ResourceCPU] = *resource.NewMilliQuantity(
+				step.Resources.Limits.CPU, resource.DecimalSI)
 		}
 	}
 	if step.Resources != nil && step.Resources.Requests != nil {
@@ -226,14 +220,9 @@ func toResources(step *engine.Step) v1.ResourceRequirements {
 			resources.Requests[v1.ResourceMemory] = *resource.NewQuantity(
 				step.Resources.Requests.Memory, resource.BinarySI)
 		}
-		if step.Resources.Requests.CPU != "" {
-			cpu, err := resource.ParseQuantity(step.Resources.Requests.CPU)
-			if err != nil {
-				// TODO: how we should print this error?
-				log.Println(err)
-			} else {
-				resources.Requests[v1.ResourceCPU] = cpu
-			}
+		if step.Resources.Requests.CPU > int64(0) {
+			resources.Requests[v1.ResourceCPU] = *resource.NewMilliQuantity(
+				step.Resources.Requests.CPU, resource.DecimalSI)
 		}
 	}
 	return resources

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -141,8 +141,8 @@ type (
 	// ResourceObject describes compute resource
 	// requirements.
 	ResourceObject struct {
-		CPU    string `json:"cpu,omitempty"`
-		Memory int64  `json:"memory,omitempty"`
+		CPU    int64 `json:"cpu,omitempty"`
+		Memory int64 `json:"memory,omitempty"`
 	}
 
 	// Secret represents a secret variable.

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -141,8 +141,8 @@ type (
 	// ResourceObject describes compute resource
 	// requirements.
 	ResourceObject struct {
-		CPU    int64 `json:"cpu,omitempty"`
-		Memory int64 `json:"memory,omitempty"`
+		CPU    string `json:"cpu,omitempty"`
+		Memory int64  `json:"memory,omitempty"`
 	}
 
 	// Secret represents a secret variable.


### PR DESCRIPTION
fixes #17 

please note that cpu needs https://github.com/drone/drone-yaml/pull/17 in order to work. Otherwise it will not add anything.

`CPU` is modified from int64 to string because with int64 it is impossible? to get it working. `int64(1)` in kubernetes means 1 CPU, and if we want to use less than one cpu we need to use string.