### PR TITLE
Adding volume host path type to spec.

### DIFF
--- a/engine/const.go
+++ b/engine/const.go
@@ -112,3 +112,65 @@ func (r *RunPolicy) UnmarshalJSON(b []byte) error {
 	*r = runPolicyName[s]
 	return nil
 }
+
+// VolumeHostPathType defines the type of a host mount
+// inside a pod; https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
+type VolumeHostPathType int
+
+// VolumeHostPathType enumeration.
+const (
+	HostPathDirectoryOrCreate VolumeHostPathType = iota
+	HostPathDirectory
+	HostPathFileOrCreate
+	HostPathFile
+	HostPathSocket
+	HostPathCharDev
+	HostPathBlockDev
+)
+
+func (h VolumeHostPathType) String() string {
+	return hostPathTypeID[h]
+}
+
+var hostPathTypeID = map[VolumeHostPathType]string{
+	HostPathDirectoryOrCreate: "dir-or-create",
+	HostPathDirectory:         "path-dir",
+	HostPathFileOrCreate:      "file-or-create",
+	HostPathFile:              "file",
+	HostPathSocket:            "socket",
+	HostPathCharDev:           "char-dev",
+	HostPathBlockDev:          "block-dev",
+}
+
+var hostPathTypeName = map[string]VolumeHostPathType{
+	"dir-or-create":  HostPathDirectoryOrCreate,
+	"path-dir":       HostPathDirectory,
+	"file-or-create": HostPathFileOrCreate,
+	"file":           HostPathFile,
+	"socket":         HostPathSocket,
+	"char-dev":       HostPathCharDev,
+	"block-dev":      HostPathBlockDev,
+}
+
+// MarshalJSON marshals the string representation of the
+// host path type to JSON.
+func (h *VolumeHostPathType) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString(hostPathTypeID[*h])
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
+}
+
+// UnmarshalJSON unmarshals the json representation of the
+// host path type from a string value.
+func (h *VolumeHostPathType) UnmarshalJSON(b []byte) error {
+	// unmarshal as string
+	var s string
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	// lookup value
+	*h = hostPathTypeName[s]
+	return nil
+}

--- a/engine/const_test.go
+++ b/engine/const_test.go
@@ -231,3 +231,149 @@ func TestPullPolicy_String(t *testing.T) {
 		}
 	}
 }
+
+//
+// volume host path type unit tests.
+//
+
+func TestVolumeHostPathType_Marshal(t *testing.T) {
+	tests := []struct {
+		hostPathType VolumeHostPathType
+		data         string
+	}{
+		{
+			hostPathType: HostPathDirectoryOrCreate,
+			data:         `"dir-or-create"`,
+		},
+		{
+			hostPathType: HostPathDirectory,
+			data:         `"path-dir"`,
+		},
+		{
+			hostPathType: HostPathFileOrCreate,
+			data:         `"file-or-create"`,
+		},
+		{
+			hostPathType: HostPathFile,
+			data:         `"file"`,
+		},
+		{
+			hostPathType: HostPathSocket,
+			data:         `"socket"`,
+		},
+		{
+			hostPathType: HostPathCharDev,
+			data:         `"char-dev"`,
+		},
+		{
+			hostPathType: HostPathBlockDev,
+			data:         `"block-dev"`,
+		},
+	}
+	for _, test := range tests {
+		data, err := json.Marshal(&test.hostPathType)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if bytes.Equal([]byte(test.data), data) == false {
+			t.Errorf("Failed to marshal host path type %s", test.hostPathType)
+		}
+	}
+}
+
+func TestRunVolumeHostPathType_Unmarshal(t *testing.T) {
+	tests := []struct {
+		hostPathType VolumeHostPathType
+		data         string
+	}{
+		{
+			hostPathType: HostPathDirectoryOrCreate,
+			data:         `"dir-or-create"`,
+		},
+		{
+			hostPathType: HostPathDirectory,
+			data:         `"path-dir"`,
+		},
+		{
+			hostPathType: HostPathFileOrCreate,
+			data:         `"file-or-create"`,
+		},
+		{
+			hostPathType: HostPathFile,
+			data:         `"file"`,
+		},
+		{
+			hostPathType: HostPathSocket,
+			data:         `"socket"`,
+		},
+		{
+			hostPathType: HostPathCharDev,
+			data:         `"char-dev"`,
+		},
+		{
+			hostPathType: HostPathBlockDev,
+			data:         `"block-dev"`,
+		},
+	}
+	for _, test := range tests {
+		var hostPathType VolumeHostPathType
+		err := json.Unmarshal([]byte(test.data), &hostPathType)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if got, want := hostPathType, test.hostPathType; got != want {
+			t.Errorf("Want host path type %q, got %q", want, got)
+		}
+	}
+}
+
+func TestVolumeHostPathType_UnmarshalTypeError(t *testing.T) {
+	var hostPathType VolumeHostPathType
+	err := json.Unmarshal([]byte("[]"), &hostPathType)
+	if _, ok := err.(*json.UnmarshalTypeError); !ok {
+		t.Errorf("Expect unmarshal error return when JSON invalid")
+	}
+}
+
+func TestVolumeHostPathType_String(t *testing.T) {
+	tests := []struct {
+		hostPathType VolumeHostPathType
+		value        string
+	}{
+		{
+			hostPathType: HostPathDirectoryOrCreate,
+			value:        "dir-or-create",
+		},
+		{
+			hostPathType: HostPathDirectory,
+			value:        "path-dir",
+		},
+		{
+			hostPathType: HostPathFileOrCreate,
+			value:        "file-or-create",
+		},
+		{
+			hostPathType: HostPathFile,
+			value:        "file",
+		},
+		{
+			hostPathType: HostPathSocket,
+			value:        "socket",
+		},
+		{
+			hostPathType: HostPathCharDev,
+			value:        "char-dev",
+		},
+		{
+			hostPathType: HostPathBlockDev,
+			value:        "block-dev",
+		},
+	}
+	for _, test := range tests {
+		if got, want := test.hostPathType.String(), test.value; got != want {
+			t.Errorf("Want host path type string %q, got %q", want, got)
+		}
+	}
+}

--- a/engine/kube/util.go
+++ b/engine/kube/util.go
@@ -137,11 +137,28 @@ func toVolumes(spec *engine.Spec, step *engine.Step) []v1.Volume {
 			continue
 		}
 		volume := v1.Volume{Name: vol.Metadata.UID}
-		source := v1.HostPathDirectoryOrCreate
+
+		var hostPathType v1.HostPathType
+		switch vol.HostPath.Type {
+		case engine.HostPathDirectoryOrCreate:
+			hostPathType = v1.HostPathDirectoryOrCreate
+		case engine.HostPathDirectory:
+			hostPathType = v1.HostPathDirectory
+		case engine.HostPathFileOrCreate:
+			hostPathType = v1.HostPathFileOrCreate
+		case engine.HostPathFile:
+			hostPathType = v1.HostPathFile
+		case engine.HostPathSocket:
+			hostPathType = v1.HostPathSocket
+		case engine.HostPathCharDev:
+			hostPathType = v1.HostPathCharDev
+		case engine.HostPathBlockDev:
+			hostPathType = v1.HostPathBlockDev
+		}
 		if vol.HostPath != nil {
 			volume.HostPath = &v1.HostPathVolumeSource{
 				Path: vol.HostPath.Path,
-				Type: &source,
+				Type: &hostPathType,
 			}
 		}
 		if vol.EmptyDir != nil {
@@ -154,7 +171,7 @@ func toVolumes(spec *engine.Spec, step *engine.Step) []v1.Volume {
 			// these directories.
 			volume.HostPath = &v1.HostPathVolumeSource{
 				Path: filepath.Join("/tmp", "drone", spec.Metadata.Namespace, vol.Metadata.UID),
-				Type: &source,
+				Type: &hostPathType,
 			}
 		}
 		to = append(to, volume)

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -197,6 +197,7 @@ type (
 	// VolumeHostPath mounts a file or directory from the
 	// host node's filesystem into your container.
 	VolumeHostPath struct {
-		Path string `json:"path,omitempty"`
+		Path string             `json:"path,omitempty"`
+		Type VolumeHostPathType `json:"type"`
 	}
 )

--- a/samples/10_docker.json
+++ b/samples/10_docker.json
@@ -1,15 +1,15 @@
 {
 	"metadata": {
 		"uid": "uid_GPzK101Yka7Hf9JD",
-		"namespace": "ns_cwOiiTAoLeYVHWVv",
+		"namespace": "ns-2iwm3tmsu347isp30884hkdm5040rcwz",
 		"name": "docker_test"
 	},
 	"secrets": null,
 	"steps": [
 		{
 			"metadata": {
-				"uid": "uid_gkZrU925ZbAWEDoy",
-				"namespace": "ns_cwOiiTAoLeYVHWVv",
+				"uid": "uid-2iwm3tmsu347isp30884hkdm5040rcwd",
+				"namespace": "ns-2iwm3tmsu347isp30884hkdm5040rcwz",
 				"name": "ping"
 			},
 			"docker": {
@@ -34,12 +34,13 @@
         "volumes": [
             {
                 "metadata": {
-                    "uid": "uid_NttbpIbQLKCyG8uI",
-                    "namespace": "ns_cwOiiTAoLeYVHWVv",
+                    "uid": "uid-29sjd7tmsu347isp30884hkdm5040r",
+                    "namespace": "ns-2iwm3tmsu347isp30884hkdm5040rcwz",
                     "name": "dockersock"
                 },
                 "host": {
-					"path": "/var/run/docker.sock"
+					"path": "/var/run/docker.sock",
+					"type": "socket"
 				}
             }
         ]


### PR DESCRIPTION
Exposing all valid volume host path types(https://kubernetes.io/docs/concepts/storage/volumes/#hostpath)
* DirectoryOrCreate
* Directory
* FileOrCreate
* File
* Socket
* CharDevice
* BlockDevice

By default the `DirectoryOrCreate` type was being used when mounting a host volume, which was causing some pipelines which rely on the `docker.sock` being available inside the step pod container to fail with: `MountVolume.SetUp failed for volume "c18m372vorpojl4s9aj0kz2vaqrvxbmi" : hostPath type check failed: /var/run/docker.sock is not a directory`

