### PR TITLE
Allow line-log circling

### DIFF
--- a/runtime/line.go
+++ b/runtime/line.go
@@ -49,12 +49,6 @@ func newWriter(state *State) *lineWriter {
 }
 
 func (w *lineWriter) Write(p []byte) (n int, err error) {
-	// if the maximum log size has been exceeded, the
-	// log entry is silently ignored.
-	if w.size >= w.limit {
-		return len(p), nil
-	}
-
 	out := string(p)
 	if w.rep != nil {
 		out = w.rep.Replace(out)
@@ -82,6 +76,11 @@ func (w *lineWriter) Write(p []byte) (n int, err error) {
 
 		if w.state.hook.GotLine != nil {
 			w.state.hook.GotLine(w.state, line)
+		}
+
+		for w.size+len(part) >= w.limit {
+			w.size -= len(w.lines[0].Message)
+			w.lines = w.lines[1:]
 		}
 		w.size = w.size + len(part)
 		w.num++

--- a/runtime/line_test.go
+++ b/runtime/line_test.go
@@ -114,3 +114,31 @@ func TestLineReplacer(t *testing.T) {
 		t.Errorf("Expect nil replacer when no masked secrets")
 	}
 }
+
+func TestLineCircling(t *testing.T) {
+	hook := &Hook{}
+	state := &State{}
+
+	state.hook = hook
+	state.Step = &engine.Step{}
+	state.config = &engine.Spec{}
+	state.config.Secrets = []*engine.Secret{
+		{Metadata: engine.Metadata{Name: "foo"}, Data: "bar"},
+	}
+
+	w := newWriter(state)
+	w.limit = 25
+	w.Write([]byte("foobar1"))
+	w.Write([]byte("foobar2"))
+	w.Write([]byte("foobar3"))
+
+	if len(w.lines) != 2 {
+		t.Errorf("Got %d lines, want %d lines", len(w.lines), 2)
+	}
+	if got, want := w.lines[0].Message, "foo********2"; got != want {
+		t.Errorf("Got line %q, want %q", got, want)
+	}
+	if got, want := w.lines[1].Message, "foo********3"; got != want {
+		t.Errorf("Got line %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
If the length of the log exceeds the limit, drop the oldest lines to fill the new ones.