### PR TITLE
Resolve pod could be scheduled by node name.

### DIFF
--- a/engine/kube/kube.go
+++ b/engine/kube/kube.go
@@ -134,19 +134,7 @@ func (e *kubeEngine) Start(ctx context.Context, spec *engine.Spec, step *engine.
 	}
 
 	if e.node != "" {
-		pod.Spec.Affinity = &v1.Affinity{
-			NodeAffinity: &v1.NodeAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-					NodeSelectorTerms: []v1.NodeSelectorTerm{{
-						MatchExpressions: []v1.NodeSelectorRequirement{{
-							Key:      "kubernetes.io/hostname",
-							Operator: v1.NodeSelectorOpIn,
-							Values:   []string{e.node},
-						}},
-					}},
-				},
-			},
-		}
+		pod.Spec.NodeName = e.node
 	}
 
 	_, err := e.client.CoreV1().Pods(spec.Metadata.Namespace).Create(pod)


### PR DESCRIPTION
fix #72 

drone-runtime use [node affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) to schedule a pod on the same node, it match the name of node to `kubernetes.io/hostname` label. Usually it works well. But if `kubernetes.io/hostname` label does not use the name of node it can make a problem. 

 I have resolved by using the [node name](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodename), it comes from [the discourse](https://discourse.drone.io/t/drone-on-k8s-failedscheduling/3854/8). Thanks