### PR TITLE
Updating log capture to support configurable size limit.

### DIFF
--- a/engine/spec.go
+++ b/engine/spec.go
@@ -35,6 +35,8 @@ type (
 		// VMWare Fusion settings. These settings are only
 		// used by the VMWare runtime driver.
 		Fusion *FusionConfig `json:"fusion,omitempty"`
+
+		LoggingConfig `json:"logging,omitempty"`
 	}
 
 	// Step defines a pipeline step.
@@ -203,5 +205,10 @@ type (
 	// host node's filesystem into your container.
 	VolumeHostPath struct {
 		Path string `json:"path,omitempty"`
+	}
+
+	// LoggingConfig configures how application logs are captured
+	LoggingConfig struct {
+		LogSizeLimitMB int `json:"logSizeLimitMB,omitempty"`
 	}
 )

--- a/runtime/line.go
+++ b/runtime/line.go
@@ -44,7 +44,12 @@ func newWriter(state *State) *lineWriter {
 	w.now = time.Now().UTC()
 	w.state = state
 	w.rep = newReplacer(state.config.Secrets)
-	w.limit = 5242880 // 5MB max log size
+	w.limit = state.config.LoggingConfig.LogSizeLimitMB
+
+	if w.limit == 0 {
+		w.limit = 5242880 // 5MB default max log size
+	}
+
 	return w
 }
 


### PR DESCRIPTION
Adding support for configurable size limit of log capture. Not sure if its appropriate to call this "LoggingConfig", also not sure if there is any specific reason 5MB was chose.